### PR TITLE
Allow any port to be used for server

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Then, to join somebody else's existing youtube sync session, visit `localhost:80
 
 If you notice any bugs, create a GitHub issue with the title being a very short summary of the problem, e.g. `Sync not working on start`, and the description being the _exact_ steps to reproduce the issue. If we do not have the _exact_ steps, we can't figure out what's wrong and can't fix it.
 
-If you notice any room for improvement, create a GitHub issue with the title being a very short summary of the improvement, e.g. `Improve session scalability`, and the description being the improvement you would like to see made. Feel free to add hints on the approach you woul take.
+If you notice any room for improvement, create a GitHub issue with the title being a very short summary of the improvement, e.g. `Improve session scalability`, and the description being the improvement you would like to see made. Feel free to add hints on the approach you would take.
 
 #### Contributing
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ yarn start
 
 ### How to
 
-To create a new youtube sync session, open your browser and visit `localhost:8088/start/choose_session_id/encoded_youtube_url`, where `choose_session_id` is any alphanumeric string and `encoded_youtube_url` is the link to a youtube video encoded using encodeURIComponent.
+To create a new youtube sync session, open your browser and visit `localhost:8000/start/choose_session_id/encoded_youtube_url`, where `choose_session_id` is any alphanumeric string and `encoded_youtube_url` is the link to a youtube video encoded using encodeURIComponent.
 
-Example of creating a new session with session id `abc123` and youtube url `https://www.youtube.com/watch?v=yB1xfGv_PY8`: `localhost:8088/start/abc123/https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DjEJUa64NU7s`
+Example of creating a new session with session id `abc123` and youtube url `https://www.youtube.com/watch?v=yB1xfGv_PY8`: `localhost:8000/start/abc123/https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DjEJUa64NU7s`
 
-Then, to join somebody else's existing youtube sync session, visit `localhost:8088/watch/abc123` in a new browser.
+Then, to join somebody else's existing youtube sync session, visit `localhost:8000/watch/abc123` in a new browser.
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Install youtube-together with `npm install youtube-together --save`. Start youtube-together server with `cd node_modules/youtube-together && npm start`. Scroll down to _How to_ to get started creating your first youtube-together session.
 
+To use a port other than the default server port (8000), run `cd node_modules/youtube-together && PORT=8123 npm start`, 8123 can be replaced by whatever port your heart desires.
+
 ### Setup from GitHub repo
 
 ```

--- a/client/src/components/session/Session.js
+++ b/client/src/components/session/Session.js
@@ -2,13 +2,10 @@ import React, { useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { useHistory } from "react-router-dom";
 import Video from "../video/Video";
-import getConfig from "../../configs/getConfig";
-
-const config = getConfig();
 
 const Session = (props) => {
   const history = useHistory();
-  const url = `ws://${window.location.hostname}:${config.sockets.port}/`;
+  const url = `ws://${window.location.hostname}:${window.location.port}/`;
   const socket = new WebSocket(url);
   let sessID = props.sessionID;
 

--- a/client/src/configs/development.config.json
+++ b/client/src/configs/development.config.json
@@ -1,6 +1,0 @@
-{
-  "sockets": {
-    "host": "localhost",
-    "port": 8088
-  }
-}

--- a/client/src/configs/getConfig.js
+++ b/client/src/configs/getConfig.js
@@ -1,9 +1,0 @@
-/**
- * Get the config for the current build type, which
- * ensures that only the given config is included in the build
- */
-export default function getConfig() {
-  return process.env.REACT_APP_BUILD_TYPE === "development"
-    ? require("./development.config.json")
-    : require("./production.config.json");
-}

--- a/client/src/configs/production.config.json
+++ b/client/src/configs/production.config.json
@@ -1,6 +1,0 @@
-{
-  "sockets": {
-    "host": "youtubesync.somedomain.com",
-    "port": 8088
-  }
-}

--- a/server/server.js
+++ b/server/server.js
@@ -13,7 +13,7 @@ const INDEX_HTML_PATH = path.join(BUILD_PATH, "index.html");
 
 app.use(express.static(path.join(__dirname, "../client", "build")));
 
-const PORT = process.env.PORT || 8088;
+const PORT = process.env.PORT || 8000;
 
 const server = require("http").createServer();
 const WebSocket = require("ws").Server;


### PR DESCRIPTION
- [x] Remove config files
- [x] Allow specifying port using PORT=XXXX when doing `yarn start` (e.g. `PORT=9123 yarn start`)